### PR TITLE
Handle missing permited key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2021-07-08
+
+### Fix
+
+- typo `permited` -> `permitted`
+
+### Enhancements
+
+- Dont add a missing permitted key on filter results
+
 ## [0.0.5] - 2021-03-18
 
 ### Features
@@ -19,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add lib documentation
 
-[unreleased]: https://github.com/brainnco/strong_params/compare/v0.0.5...main
+[unreleased]: https://github.com/brainnco/strong_params/compare/v0.1.0...main
+[0.1.0]: https://github.com/brainnco/strong_params/compare/v0.0.5...v0.1.0
 [0.0.5]: https://github.com/brainnco/strong_params/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/brainnco/strong_params/compare/v0.0.3...v0.0.4

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ defmodule YourPhoenixApp.UserController do
 
   alias YourPhoenixApp.User
 
-  filter_for(:create, required: [:name, :email], permited: [:nickname])
+  filter_for(:create, required: [:name, :email], permitted: [:nickname])
 
   def create(conn, %{name: _, email: _} = params) do
 
@@ -92,7 +92,7 @@ defmodule YourPhoenixApp.UserController do
 
   action_fallback(YourPhoenixApp.Fallback)
 
-  filter_for(:create, required: [:name, :email], permited: [:nickname])
+  filter_for(:create, required: [:name, :email], permitted: [:nickname])
 
   ...
 
@@ -111,8 +111,8 @@ end
 You must call `filter_for/2` for each action you want to filter the params.
 
 ```elixir
-filter_for(:create, required: [:name, :email], permited: [:nickname])
-filter_for(:update, permited: [:name, :email, :nickname])
+filter_for(:create, required: [:name, :email], permitted: [:nickname])
+filter_for(:update, permitted: [:name, :email, :nickname])
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ mix.exs
 ```elixir
 def deps do
   [
-    {:strong_params, "~> 0.0.5"}
+    {:strong_params, "~> 0.1.0"}
   ]
 end
 ```

--- a/lib/strong_params.ex
+++ b/lib/strong_params.ex
@@ -10,14 +10,14 @@ defmodule StrongParams do
   controller action. This macro must be called inside a Phoenix controller implementation.
 
   The first given argument must be a valid action name. The second must be a `Keyword`
-  with the list of required and permited parameters. The `Keyword` may have both lists or
+  with the list of required and permitted parameters. The `Keyword` may have both lists or
   just one of them:
 
-    * `:permited` - List of parameters to keep. If some of listed parameters is missing no error is returned.
+    * `:permitted` - List of parameters to keep. If some of listed parameters is missing no error is returned.
     * `:required` - List of parameters that are required. In case of missing parameters a error will be returned with a map enumerating the missing parameters.
 
   ```elixir
-  filter_for(:index, required: [:name, :email], permited: [:nickname])
+  filter_for(:index, required: [:name, :email], permitted: [:nickname])
   ```
 
   For nested parameters you must use a keyword.
@@ -25,7 +25,7 @@ defmodule StrongParams do
   Exemple:
 
   ```elixir
-  filter_for(:index, required: [:name, :email, address: [:street, :city]], permited: [:nickname])
+  filter_for(:index, required: [:name, :email, address: [:street, :city]], permitted: [:nickname])
 
   # Expected filtered parameters
   %{
@@ -59,9 +59,9 @@ defmodule StrongParams do
 
   @type parameters_list :: [atom | [{atom, parameters_list()}]]
   @type filters ::
-          [required: parameters_list, permited: parameters_list]
+          [required: parameters_list, permitted: parameters_list]
           | [required: parameters_list]
-          | [permited: parameters_list]
+          | [permitted: parameters_list]
 
   @spec filter_for(atom, filters()) :: any
   defmacro filter_for(filter_action, filters) do

--- a/lib/strong_params/filter.ex
+++ b/lib/strong_params/filter.ex
@@ -7,22 +7,22 @@ defmodule StrongParams.Filter do
 
   def apply(params, filters) do
     required = Keyword.get(filters, :required, [])
-    permited = Keyword.get(filters, :permited, [])
+    permitted = Keyword.get(filters, :permitted, [])
 
     required
     |> filter_required(params)
-    |> filter_permited(permited, params)
+    |> filter_permitted(permitted, params)
   end
 
   defp filter_required(required, params) do
     apply_filters(%{}, required, params, :required)
   end
 
-  defp filter_permited(%Error{} = error, _permited, _params), do: error
+  defp filter_permitted(%Error{} = error, _permitted, _params), do: error
 
-  defp filter_permited(initial, permited, params) do
+  defp filter_permitted(initial, permitted, params) do
     %{}
-    |> apply_filters(permited, params, :permited)
+    |> apply_filters(permitted, params, :permitted)
     |> deep_merge(initial)
   end
 
@@ -45,10 +45,13 @@ defmodule StrongParams.Filter do
 
     partial_result =
       case {params_value, mode} do
-        {:key_not_found, :permited} ->
+        {:key_not_found, :permitted} ->
           result
 
         {:key_not_found, :required} ->
+          add_to_result(result, filter, apply_filters(%{}, filter_rest, %{}, mode), mode)
+
+        {nil, _mode} ->
           add_to_result(result, filter, apply_filters(%{}, filter_rest, %{}, mode), mode)
 
         _other ->
@@ -85,7 +88,7 @@ defmodule StrongParams.Filter do
   defp add_to_result(%{}, key, :key_not_found, :required),
     do: %Error{type: "required", errors: Map.new([{key, "is required"}])}
 
-  defp add_to_result(result, _key, :key_not_found, :permited), do: result
+  defp add_to_result(result, _key, :key_not_found, :permitted), do: result
 
   defp add_to_result(%Error{errors: first_errors} = error, key, %Error{errors: errors}, _mode),
     do: %{error | errors: Map.put(first_errors, key, errors)}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule StrongParams.MixProject do
   use Mix.Project
 
-  @version "0.0.5"
+  @version "0.1.0"
   @description "Filter request parameters in a Phoenix app"
   @links %{"GitHub" => "https://github.com/brainnco/strong_params"}
 

--- a/test/strong_params/filter_plug_test.exs
+++ b/test/strong_params/filter_plug_test.exs
@@ -6,7 +6,7 @@ defmodule StrongParams.FilterPlugTest do
 
   describe "init/1" do
     test "keep options" do
-      opts = [required: [:name], permited: [:alias], caller: :module]
+      opts = [required: [:name], permitted: [:alias], caller: :module]
 
       assert FilterPlug.init(opts) == opts
     end

--- a/test/strong_params/filter_test.exs
+++ b/test/strong_params/filter_test.exs
@@ -173,6 +173,16 @@ defmodule StrongParams.FilterTest do
              }
     end
 
+    test "when a permited is a map and not given on params" do
+      params = %{"name" => "Johnny Lawrence"}
+
+      filters = [permited: [:name, address: [:street, :city]]]
+
+      result = Filter.apply(params, filters)
+
+      assert result == %{name: "Johnny Lawrence"}
+    end
+
     test "error in list item" do
       params = %{
         "name" => "Johnny Lawrence",

--- a/test/strong_params/filter_test.exs
+++ b/test/strong_params/filter_test.exs
@@ -193,6 +193,16 @@ defmodule StrongParams.FilterTest do
       assert result == %{name: "Johnny Lawrence", address: %{}}
     end
 
+    test "when a permitted is a map and was given an empty map on params" do
+      params = %{"name" => "Johnny Lawrence", "address" => %{}}
+
+      filters = [permitted: [:name, address: [:street, :city]]]
+
+      result = Filter.apply(params, filters)
+
+      assert result == %{name: "Johnny Lawrence", address: %{}}
+    end
+
     test "error in list item" do
       params = %{
         "name" => "Johnny Lawrence",

--- a/test/strong_params/filter_test.exs
+++ b/test/strong_params/filter_test.exs
@@ -19,14 +19,14 @@ defmodule StrongParams.FilterTest do
              }
     end
 
-    test "filter and return permited fields" do
+    test "filter and return permitted fields" do
       params = %{
         "name" => "Johnny Lawrence",
         "description" => "user description",
         "role" => "admin"
       }
 
-      result = Filter.apply(params, permited: [:name, :description])
+      result = Filter.apply(params, permitted: [:name, :description])
 
       assert result == %{
                name: "Johnny Lawrence",
@@ -34,14 +34,14 @@ defmodule StrongParams.FilterTest do
              }
     end
 
-    test "dont return error when permited field is not found" do
+    test "dont return error when permitted field is not found" do
       params = %{
         "name" => "Johnny Lawrence",
         "description" => "user description",
         "role" => "admin"
       }
 
-      result = Filter.apply(params, permited: [:nickname, :name, :description])
+      result = Filter.apply(params, permitted: [:nickname, :name, :description])
 
       assert result == %{
                name: "Johnny Lawrence",
@@ -71,7 +71,7 @@ defmodule StrongParams.FilterTest do
              }
     end
 
-    test "filter and return required and permited" do
+    test "filter and return required and permitted" do
       params = %{
         "name" => "Johnny Lawrence",
         "address" => %{
@@ -84,7 +84,7 @@ defmodule StrongParams.FilterTest do
 
       filters = [
         required: [:name, address: [:street]],
-        permited: [attachments: [info: [:type, :size]]]
+        permitted: [attachments: [info: [:type, :size]]]
       ]
 
       result = Filter.apply(params, filters)
@@ -96,7 +96,7 @@ defmodule StrongParams.FilterTest do
              }
     end
 
-    test "merge required and permited" do
+    test "merge required and permitted" do
       params = %{
         "name" => "Johnny Lawrence",
         "attachments" => %{
@@ -106,7 +106,7 @@ defmodule StrongParams.FilterTest do
 
       filters = [
         required: [:name, attachments: [info: [:type]]],
-        permited: [attachments: [info: [:size]]]
+        permitted: [attachments: [info: [:size]]]
       ]
 
       result = Filter.apply(params, filters)
@@ -173,14 +173,24 @@ defmodule StrongParams.FilterTest do
              }
     end
 
-    test "when a permited is a map and not given on params" do
+    test "when a permitted is a map and not given on params" do
       params = %{"name" => "Johnny Lawrence"}
 
-      filters = [permited: [:name, address: [:street, :city]]]
+      filters = [permitted: [:name, address: [:street, :city]]]
 
       result = Filter.apply(params, filters)
 
       assert result == %{name: "Johnny Lawrence"}
+    end
+
+    test "when a permitted is a map and was given a nil on params" do
+      params = %{"name" => "Johnny Lawrence", "address" => nil}
+
+      filters = [permitted: [:name, address: [:street, :city]]]
+
+      result = Filter.apply(params, filters)
+
+      assert result == %{name: "Johnny Lawrence", address: %{}}
     end
 
     test "error in list item" do
@@ -287,7 +297,7 @@ defmodule StrongParams.FilterTest do
       assert params_with_not_a_map_result == expected_error
     end
 
-    test "dont return permited when required has errors" do
+    test "dont return permitted when required has errors" do
       params = %{
         "name" => "Johnny Lawrence",
         "address" => %{
@@ -298,7 +308,7 @@ defmodule StrongParams.FilterTest do
         }
       }
 
-      filters = [required: [attachments: [info: [:type, :size]]], permited: [:name]]
+      filters = [required: [attachments: [info: [:type, :size]]], permitted: [:name]]
 
       result = Filter.apply(params, filters)
 


### PR DESCRIPTION
## Motivation

Whe a filter permitted key is an map and its missing on given params, `StrongParams` is returning the key in the result with an empty map.

## Proposed solution

Dont add the missing permitted key on filter result.

Fixed a typo
